### PR TITLE
add ADC differential support

### DIFF
--- a/fw/code/source/adc.c
+++ b/fw/code/source/adc.c
@@ -21,9 +21,10 @@ uint8_t data adc_channel_index = 0;
 uint8_t xdata adc_channel_count = 0;
 uint8_t xdata adc_int_dec = 1;
 uint8_t xdata adc_int_dec_max = 1;
-uint16_t data adc_results[MAX_ANALOG_INPUTS];            
+int16_t data adc_results[MAX_ANALOG_INPUTS];            
 
-uint8_t xdata adc_mux_tbl[MAX_ANALOG_INPUTS] = { 0 };
+uint8_t xdata adc_mux_tbl_n[MAX_ANALOG_INPUTS] = { 0 };
+uint8_t xdata adc_mux_tbl_p[MAX_ANALOG_INPUTS] = { 0 };
 
 uint16_t adc_timer_count;
 
@@ -58,8 +59,8 @@ void ADC0_Init(void)
 	REF0CN = DEFAULT_REF0CN;
 	ADC0CF = DEFAULT_ADC0CF;
 	
-	AMX0P = adc_mux_tbl[0];
-	AMX0N = 0x1F;
+	AMX0P = adc_mux_tbl_n[0];
+	AMX0N = ADC_GND;
 	
 	EIE1 |= 0x08;
 }
@@ -72,7 +73,7 @@ void ADC0_Set_Reference(uint8_t value)
 
 void ADC0_ISR (void) interrupt 10
 {
-	static long xdata adc_accumulator[MAX_ANALOG_INPUTS] = { 0 };
+	static int32_t xdata adc_accumulator[MAX_ANALOG_INPUTS] = { 0 };
 	int xdata i;
 
 	//P3 = P3 & ~0x40;
@@ -89,7 +90,7 @@ void ADC0_ISR (void) interrupt 10
 			adc_int_dec = adc_int_dec_max;
 
 			for(i = 0; i < adc_channel_count; i++) {
-				adc_results[i] = adc_accumulator[i] / adc_int_dec_max;
+				adc_results[i] = (int16_t) (adc_accumulator[i] / adc_int_dec_max);
 				adc_accumulator[i] = 0;
 			}
 
@@ -101,17 +102,6 @@ void ADC0_ISR (void) interrupt 10
 	} else {
 		adc_channel_index++;
 	}
-	
-	/*
-	adc_results[adc_channel_index] = ADC0;
-	adc_channel_index++;
-	
-	if (adc_channel_index == adc_channel_count) {
-		adc_complete = 1;
-		build_adc_packet();
-		adc_channel_index = 0;
-	}
-	*/
 	
 	//P3 = P3 | 0x40;
 }

--- a/fw/code/source/globals.h
+++ b/fw/code/source/globals.h
@@ -44,6 +44,9 @@
 #define ADC_P4_6 0x0F // 001111b
 #define ADC_P4_7 0x22 // 100010b
 
+#define ADC_GND 0x1F  // 011111b
+#define ADC_VREF 0x1E // 011110b
+
 // error code used globally for all routines
 enum _config_error
 {

--- a/fw/code/source/timers.c
+++ b/fw/code/source/timers.c
@@ -13,7 +13,8 @@ extern uint8_t xdata daq_state;
 
 extern uint8_t data adc_channel_index;
 extern uint8_t xdata adc_channel_count;
-extern uint8_t xdata adc_mux_tbl[MAX_ANALOG_INPUTS];
+extern uint8_t xdata adc_mux_tbl_n[MAX_ANALOG_INPUTS];
+extern uint8_t xdata adc_mux_tbl_p[MAX_ANALOG_INPUTS];
 
 uint8_t xdata timer0_flag = 0;
 
@@ -145,10 +146,12 @@ void Timer0_ISR (void) interrupt 1
 	
 	if (daq_state == GENERAL_CTRL_ADC_ENABLE) {
 		if (adc_channel_index == (adc_channel_count - 1)) {
-			AMX0P = adc_mux_tbl[0];
+			AMX0P = adc_mux_tbl_n[0];
+			AMX0N = adc_mux_tbl_p[0];
     }
     else {
-      AMX0P = adc_mux_tbl[adc_channel_index + 1];
-    }
+      AMX0P = adc_mux_tbl_n[adc_channel_index + 1];
+			AMX0N = adc_mux_tbl_p[adc_channel_index + 1];
+		}
   }
 }

--- a/fw/standard/daq_buddy.uvopt
+++ b/fw/standard/daq_buddy.uvopt
@@ -256,10 +256,10 @@
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <Focus>0</Focus>
-      <ColumnNumber>12</ColumnNumber>
+      <ColumnNumber>2</ColumnNumber>
       <tvExpOptDlg>0</tvExpOptDlg>
-      <TopLine>331</TopLine>
-      <CurrentLine>183</CurrentLine>
+      <TopLine>644</TopLine>
+      <CurrentLine>674</CurrentLine>
       <bDave2>0</bDave2>
       <PathWithFileName>..\code\source\action.c</PathWithFileName>
       <FilenameWithoutPath>action.c</FilenameWithoutPath>
@@ -274,8 +274,8 @@
       <Focus>0</Focus>
       <ColumnNumber>0</ColumnNumber>
       <tvExpOptDlg>0</tvExpOptDlg>
-      <TopLine>76</TopLine>
-      <CurrentLine>111</CurrentLine>
+      <TopLine>17</TopLine>
+      <CurrentLine>80</CurrentLine>
       <bDave2>0</bDave2>
       <PathWithFileName>..\code\source\adc.c</PathWithFileName>
       <FilenameWithoutPath>adc.c</FilenameWithoutPath>
@@ -384,9 +384,9 @@
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <Focus>0</Focus>
-      <ColumnNumber>23</ColumnNumber>
+      <ColumnNumber>0</ColumnNumber>
       <tvExpOptDlg>0</tvExpOptDlg>
-      <TopLine>76</TopLine>
+      <TopLine>65</TopLine>
       <CurrentLine>99</CurrentLine>
       <bDave2>0</bDave2>
       <PathWithFileName>..\code\source\main.c</PathWithFileName>
@@ -432,10 +432,10 @@
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <Focus>0</Focus>
-      <ColumnNumber>0</ColumnNumber>
+      <ColumnNumber>14</ColumnNumber>
       <tvExpOptDlg>0</tvExpOptDlg>
-      <TopLine>113</TopLine>
-      <CurrentLine>146</CurrentLine>
+      <TopLine>1</TopLine>
+      <CurrentLine>21</CurrentLine>
       <bDave2>0</bDave2>
       <PathWithFileName>..\code\source\timers.c</PathWithFileName>
       <FilenameWithoutPath>timers.c</FilenameWithoutPath>

--- a/lib/libbuddy/buddy.h
+++ b/lib/libbuddy/buddy.h
@@ -135,6 +135,11 @@ typedef enum _RUNTIME_DAC_REF {
 	RUNTIME_DAC_REF_INT_2V,
 } RUNTIME_DAC_REF;
 
+typedef enum _RUNTIME_ADC_MODE {
+	RUNTIME_ADC_MODE_SINGLE_ENDED = 0,
+	RUNTIME_ADC_MODE_DIFFERENTIAL,
+} RUNTIME_ADC_MODE;
+
 /**
  * \enum RUNTIME_ADC_REF 
  * \brief C8051 ADC reference voltage
@@ -327,6 +332,7 @@ typedef struct _ctrl_general_t {
 typedef struct _ctrl_runtime_t {
 	uint8_t dac_power;
 	uint8_t dac_ref;
+	uint8_t adc_mode;
 	uint8_t adc_ref;
 	uint8_t adc_gain;
 	uint8_t pwm_mode;
@@ -349,11 +355,11 @@ typedef struct _ctrl_timing_t {
 /**
  * \struct general_packet_t
  * \brief General-purpose encoder packet type.  Channel values
- *				 represent either DAC or ADC values before they are
- *				 are encoded into a frame.
+ *				 represent either DAC, ADC, or PWM values before 
+ *				 they are are encoded into a frame.
  */
 typedef struct _general_packet_t {
-	uint32_t channels[NUM_DAC_CHANNELS];
+	int32_t channels[NUM_DAC_CHANNELS];
 } general_packet_t;
 
 #endif

--- a/lib/libbuddy/usbhid_buddy.c
+++ b/lib/libbuddy/usbhid_buddy.c
@@ -126,9 +126,22 @@ int decode(uint8_t *frame, general_packet_t *packet)
 
 	for (i = BUDDY_CHAN_0; i <= BUDDY_CHAN_7; i++) {
 		if (_chan_enable[i]) {
-			if (_resolution_mode == RESOLUTION_CTRL_HIGH) {
-				packet->channels[i] = (*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset) << 8);
-				packet->channels[i] |= *(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset + 1);
+			if (_resolution_mode == RESOLUTION_CTRL_SUPER) {
+				packet->channels[i] = (*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset) << 24);
+				packet->channels[i] |= (*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset + 1) << 16);
+				packet->channels[i] |= (*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset + 2) << 8);
+				packet->channels[i] |= *(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset + 3);
+			} else if (_resolution_mode == RESOLUTION_CTRL_HIGH) {
+				if ((*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset)) & 0x80) {
+					packet->channels[i] = ((*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset)) << 8);
+					packet->channels[i] |= *(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset + 1);
+					
+					// sign extension
+					packet->channels[i] = packet->channels[i] | 0xFFFF0000;
+				} else {
+					packet->channels[i] = (*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset) << 8);
+					packet->channels[i] |= *(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset + 1);
+				}
 			} else if (_resolution_mode == RESOLUTION_CTRL_LOW) {
 				packet->channels[i] = (*(frame + BUDDY_APP_VALUE_OFFSET + codec_byte_offset));
 			} else {


### PR DESCRIPTION
1. enable ADC differential mode.  add new field to ctrl_runtime_t to
specify single ended or differential ADC mode.
2. change general_packet_t to use an int32_t for channel values.
3. use sign extension in usbhid driver when a signed int16_t is detected
to preserve proper sign.
4. modify python example to demonstrate ADC differential usage.

really going to need to break up the examples into independent routines
to demonstrate usage as it's getting to be a bit of clusterfuck.